### PR TITLE
Apipieのパラメータ設定でバリデーションチェックが働くように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'autodoc', group: :test
 
+# 20171222時点で master branchでswagger_json形式の変換がサポート
+# Githubから取得する場合はこちら
+# gem 'apipie-rails', :github => 'Apipie/apipie-rails'
 gem 'apipie-rails'
 # for Markdown
 gem 'maruku'

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,10 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'autodoc', group: :test
+group :test do
+  gem 'autodoc'
+  gem 'rspec-json_matcher'
+end
 
 # 20171222時点で master branchでswagger_json形式の変換がサポート
 # Githubから取得する場合はこちら

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       actionpack
       activesupport (>= 3.0.0)
       rspec
+    awesome_print (1.8.0)
     builder (3.2.3)
     byebug (9.1.0)
     concurrent-ruby (1.0.5)
@@ -61,6 +62,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
+    json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -118,6 +120,9 @@ GEM
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-json_matcher (0.1.6)
+      awesome_print
+      json
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
@@ -164,6 +169,7 @@ DEPENDENCIES
   maruku
   puma (~> 3.7)
   rails (~> 5.1.4)
+  rspec-json_matcher
   rspec-rails
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+  describe 'GET #show' do
+    # Userを作成
+    before { @users = FactoryBot.create_list(:user, 2) }
+    subject { get :show, params: { id: user_id } }
+
+    context 'GET with valid id' do
+      let(:user_id) { User.last.id }
+      it 'show' do
+        subject
+        expect(response.body).to be_json_including(id: user_id)
+      end
+    end
+
+    #
+    # apipieのバリデーションの動作チェック
+    #
+    context 'GET with non numeric value' do
+      let(:user_id) { 'abc' }
+      before { subject }
+      # Status Code Check
+      it 'return bad request' do
+        expect(response).to have_http_status(400)
+      end
+
+      # 例外発生とrescueの結果エラーメッセージが返る
+      it 'has error message' do
+        expect(response.body).to be_json_including(
+          code: 'invalid_parameter',
+          message: "Invalid parameter 'id' value \"#{user_id}\": Must be a number."
+        )
+      end
+
+      # 例外発生はApipieのバリデーションエラーが発生したためであることをチェック
+      it 'rescued Apipie::ParamInvalid' do
+        bypass_rescue
+        expect do
+          subject
+        end.to raise_error(Apipie::ParamInvalid)
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -46,5 +46,23 @@ RSpec.describe 'Users', type: :request do
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    #
+    # apipieのバリデーションの動作チェック
+    #
+    context 'GET with non numeric value' do
+      let(:user_id) { 'abc' }
+      before { subject }
+      it 'return bad request', autodoc: false do
+        expect(response).to have_http_status(400)
+      end
+
+      it 'has error message' do
+        expect(response.body).to be_json_including(
+          code: 'invalid_parameter',
+          message: "Invalid parameter 'id' value \"#{user_id}\": Must be a number."
+        )
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,4 +95,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # json_matcherを利用します
+  require 'rspec/json_matcher'
+  config.include RSpec::JsonMatcher
 end


### PR DESCRIPTION
param :id, :number, desc: 'user id', required: true を設定していますが、この状態だと Apipieがバリデーションを実施するより先に、before_actionでset_user が呼ばれて、そちらで ActiveRecord NotFound が発生します。

また、この時の値は、”abc” というパラメータでfindされていまいます。

findメソッドに渡すより先にパラメータのチェックができるように、before_action :apipie_validations を指定します。

